### PR TITLE
Add podspec file

### DIFF
--- a/react-native-audio.podspec
+++ b/react-native-audio.podspec
@@ -1,0 +1,22 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'react-native-audio'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = 'https://github.com/ghinwallc/react-native-audio'
+  s.source         = { :git => 'https://github.com/ghinwallc/react-native-audio', :tag => s.version }
+
+  s.requires_arc   = true
+  s.platform       = :ios, '8.0'
+
+  s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
+  s.source_files   = 'ios/*.{h,m}'
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
Hello, since this fork since more up to date, I'd like to contribute by adding .podspec file support.
It helps to keep dependencies cleaner with Cocoapods, (Podfile) but it doesn't affect users that 
aren't using Cocoapods.
